### PR TITLE
Optionally read token from systemd credentials

### DIFF
--- a/glass/__init__.py
+++ b/glass/__init__.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 
 from pathlib import Path
 from typing import Callable, Any
@@ -11,9 +12,15 @@ from glass.hoster.gitlab import GitLabHoster
 from glass.hoster.gitea import GiteaHoster
 from glass.mirror import mirror_repo
 
+def get_token(hoster: str) -> str:
+    if os.getenv("CREDENTIALS_DIRECTORY"):
+        cred_path = Path(os.getenv("CREDENTIALS_DIRECTORY")) / hoster
+        if cred_path.exists():
+            return cred_path.read_text().strip()
+
 DEFAULT_CONFIG_PATH = Path.home() / '.config' / 'glass' / 'config.json'
 HOSTERS: dict[str, Callable[[dict[str, Any]], GitHoster]] = {
-    'github': lambda acc: GitHubHoster(acc['token']),
+    'github': lambda acc: GitHubHoster(acc.get('token') or get_token("github")),
     'gitlab': lambda acc: GitLabHoster(acc['url'], acc['token']),
     'gitea': lambda acc: GiteaHoster(acc['url'], acc['token']),
     'git': lambda acc: SingleRepoGitHoster(acc['url'])


### PR DESCRIPTION
If token in config.json is unset and CREDENTIALS_DIRECTORY environment variable is set, try to get the token from the credentials directory.

Refs #5

Minimal working example:

```ini
[Unit]
Description=GitHub mirror

[Service]
Type=oneshot
LoadCredential=github:/etc/secrets/github
ExecStart=glass --config /etc/glass/config.json
```

see https://systemd.io/CREDENTIALS/  for more sophisticated usage (encrypted credentials) of `systemd credentials`.